### PR TITLE
Update Aspire 9.4.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,28 +5,28 @@
   </PropertyGroup>
 
   <ItemGroup Label="Production">
-    <PackageVersion Include="Aspire.Hosting" Version="9.3.0" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.3.0" />
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="9.3.0" />
-    <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="8.17.3" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.3" />
+    <PackageVersion Include="Aspire.Hosting" Version="9.4.1" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.4.1" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="9.4.1" />
+    <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="9.1.4" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.8" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
   </ItemGroup>
 
   <ItemGroup Label="Test-only">
-    <PackageVersion Include="JsonSchema.Net" Version="7.3.3" />
+    <PackageVersion Include="JsonSchema.Net" Version="7.4.0" />
     <PackageVersion Include="Microsoft.DotNet.RemoteExecutor" Version="9.0.0-beta.25204.5" />
     <PackageVersion Include="Microsoft.DotNet.XUnitExtensions" Version="9.0.0-beta.25164.2" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.9.0" />
-    <PackageVersion Include="Testcontainers.Elasticsearch" Version="4.3.0" />
-    <PackageVersion Include="xunit.analyzers" Version="1.15.0" />
-    <PackageVersion Include="xunit.assert" Version="2.9.0" />
-    <PackageVersion Include="xunit.core" Version="2.9.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.12.0" />
+    <PackageVersion Include="Testcontainers.Elasticsearch" Version="4.6.0" />
+    <PackageVersion Include="xunit.analyzers" Version="1.24.0" />
+    <PackageVersion Include="xunit.assert" Version="2.9.3" />
+    <PackageVersion Include="xunit.core" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updated dependencies including update to Aspire 9.4.1 packages.
Docker images may need updating also if they are out of date.

References #8 