### PR TITLE
Fix dependency version downgrade errors for Aspire.Hosting 13.3.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,9 +9,9 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.3.0" />
     <PackageVersion Include="Aspire.Hosting.Testing" Version="13.3.0" />
     <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="8.19.4" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
   </ItemGroup>
@@ -20,7 +20,7 @@
     <PackageVersion Include="JsonSchema.Net" Version="7.4.0" />
     <PackageVersion Include="Microsoft.DotNet.RemoteExecutor" Version="9.0.0-beta.25204.5" />
     <PackageVersion Include="Microsoft.DotNet.XUnitExtensions" Version="9.0.0-beta.25164.2" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.12.0" />
     <PackageVersion Include="Testcontainers.Elasticsearch" Version="4.6.0" />


### PR DESCRIPTION
## Summary

Fixes the CD build failure on the [`13.3.0` release run](https://github.com/elastic/elastic-aspire-dotnet/actions/runs/25545103026), where `dotnet restore` failed with `NU1109` (package downgrade) errors:

```
error NU1109: Detected package downgrade: Microsoft.Extensions.Hosting from 10.0.7 to centrally defined 10.0.5.
error NU1109: Detected package downgrade: Microsoft.Extensions.Configuration.Binder from 10.0.7 to centrally defined 10.0.5.
error NU1109: Detected package downgrade: Microsoft.Extensions.Hosting.Abstractions from 10.0.7 to centrally defined 10.0.5.
```

`Aspire.Hosting 13.3.0` transitively requires the `Microsoft.Extensions.*` packages at `>= 10.0.7`, but `Directory.Packages.props` still pins them to `10.0.5`. This bumps the centrally managed versions to `10.0.7` to match.

This is the same kind of fix as #19 (which addressed the analogous issue for `13.2.0`).